### PR TITLE
added poi able to update & added try-except to print_log def

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ You can modify the config `dimension_region_folder` to make entities sync during
     "source_world_directory": "./qb_multi/slot1/world",
     "destination_world_directory": "./server/world",
     "dimension_region_folder": {
-        "-1": ["DIM-1/region", "DIM-1/entities"],
-        "0": ["region", "entities"],
-        "1": ["DIM1/region", "DIM1/entities"]
+        "-1": ["DIM-1/region", "DIM-1/poi", "DIM-1/entities"],
+        "0": ["region", "poi", "entities"],
+        "1": ["DIM1/region", "DIM1/poi", "DIM1/entities"]
     }
 }
 ```

--- a/mcdreforged.plugin.json
+++ b/mcdreforged.plugin.json
@@ -1,6 +1,6 @@
 {
 	"id": "region_file_updater",
-	"version": "1.5.2",
+	"version": "1.5.1",
 	"name": "Region file Updater",
 	"description": {
 		"en_us": "A MCDR plugin to help you update region files in game",

--- a/mcdreforged.plugin.json
+++ b/mcdreforged.plugin.json
@@ -1,6 +1,6 @@
 {
 	"id": "region_file_updater",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"name": "Region file Updater",
 	"description": {
 		"en_us": "A MCDR plugin to help you update region files in game",

--- a/region_file_updater/__init__.py
+++ b/region_file_updater/__init__.py
@@ -167,9 +167,9 @@ def region_update(source: CommandSource):
 			except Exception as e:
 				msg = '失败，错误信息：{}'.format(str(e))
 				flag = False
-				if str(e)[10:35] == 'No such file or directory' and region_file.split('\\')[0] == 'poi' and os.path.exists(destination):
+				if isinstance(e, FileNotFoundError) and os.path.exists(destination):
 					os.remove(destination)
-					source.get_server().logger.info('poi 删除成功: {}'.format(destination))
+					source.get_server().logger.info('在目的地被删除的文件: {}'.format(destination))
 			else:
 				msg = '成功'
 				flag = True

--- a/region_file_updater/__init__.py
+++ b/region_file_updater/__init__.py
@@ -154,7 +154,7 @@ def region_update(source: CommandSource):
 
 	source.get_server().stop()
 	source.get_server().wait_for_start()
-	
+
 	print_log(source.get_server(), '{} 更新了 {} 个区域文件：'.format(source, len(regionList)))
 	historyList.clear()
 	for region in regionList:

--- a/region_file_updater/__init__.py
+++ b/region_file_updater/__init__.py
@@ -77,12 +77,6 @@ class Region:
 		return 'Region[x={}, z={}, dim={}]'.format(self.x, self.z, self.dim)
 
 
-def print_log(server: ServerInterface, msg: str):
-	server.logger.info(msg)
-	with open(LogFilePath, 'a') as logfile:
-		logfile.write(time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())) + ': ' + msg + '\n')
-
-
 def add_region(source: CommandSource, region: Region):
 	if region in regionList:
 		source.reply('列表中已存在该区域文件')
@@ -152,7 +146,7 @@ def region_update(source: CommandSource):
 	source.get_server().stop()
 	source.get_server().wait_for_start()
 
-	print_log(source.get_server(), '{} 更新了 {} 个区域文件：'.format(source, len(regionList)))
+	source.get_server().logger.info('{} 更新了 {} 个区域文件：'.format(source, len(regionList)))
 	historyList.clear()
 	for region in regionList:
 		for region_file in region.to_file_list():
@@ -171,7 +165,7 @@ def region_update(source: CommandSource):
 				msg = '成功'
 				flag = True
 			historyList.append((region, flag))
-			print_log(source.get_server(), '  {}: {}'.format(region, msg))
+			source.get_server().logger.info('  {}: {}'.format(region, msg))
 
 	regionList.clear()
 	time.sleep(1)

--- a/region_file_updater/__init__.py
+++ b/region_file_updater/__init__.py
@@ -77,6 +77,15 @@ class Region:
 		return 'Region[x={}, z={}, dim={}]'.format(self.x, self.z, self.dim)
 
 
+def print_log(server: ServerInterface, msg: str):
+	server.logger.info(msg)
+	with open(LogFilePath, 'a') as logfile:
+		try:
+			logfile.write(time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())) + ': ' + msg + '\n')
+		except Exception as e:
+			server.logger.info('错误写入日志文件: {}'.format(e))
+
+
 def add_region(source: CommandSource, region: Region):
 	if region in regionList:
 		source.reply('列表中已存在该区域文件')
@@ -145,8 +154,8 @@ def region_update(source: CommandSource):
 
 	source.get_server().stop()
 	source.get_server().wait_for_start()
-
-	source.get_server().logger.info('{} 更新了 {} 个区域文件：'.format(source, len(regionList)))
+	
+	print_log(source.get_server(), '{} 更新了 {} 个区域文件：'.format(source, len(regionList)))
 	historyList.clear()
 	for region in regionList:
 		for region_file in region.to_file_list():
@@ -165,7 +174,7 @@ def region_update(source: CommandSource):
 				msg = '成功'
 				flag = True
 			historyList.append((region, flag))
-			source.get_server().logger.info('  {}: {}'.format(region, msg))
+			print_log(source.get_server(), '  {}: {}'.format(region, msg))
 
 	regionList.clear()
 	time.sleep(1)

--- a/region_file_updater/__init__.py
+++ b/region_file_updater/__init__.py
@@ -79,11 +79,11 @@ class Region:
 
 def print_log(server: ServerInterface, msg: str):
 	server.logger.info(msg)
-	with open(LogFilePath, 'a') as logfile:
-		try:
+	try:
+		with open(LogFilePath, 'a') as logfile:
 			logfile.write(time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(time.time())) + ': ' + msg + '\n')
-		except Exception as e:
-			server.logger.info('错误写入日志文件: {}'.format(e))
+	except Exception as e:
+		server.logger.info('错误写入日志文件: {}'.format(e))
 
 
 def add_region(source: CommandSource, region: Region):

--- a/region_file_updater/__init__.py
+++ b/region_file_updater/__init__.py
@@ -13,9 +13,9 @@ class Config(Serializable):
 	source_world_directory: str = './qb_multi/slot1/world'
 	destination_world_directory: str = './server/world'
 	dimension_region_folder: Dict[str, Union[str, List[str]]] = {
-		'-1': 'DIM-1/region',
-		'0': 'region',
-		'1': 'DIM1/region'
+		'-1': ['DIM-1/region', 'DIM-1/poi'],
+		'0': ['region', 'poi'],
+		'1': ['DIM1/region', 'DIM1/poi']
 	}
 
 
@@ -164,6 +164,9 @@ def region_update(source: CommandSource):
 			except Exception as e:
 				msg = '失败，错误信息：{}'.format(str(e))
 				flag = False
+				if str(e)[10:35] == 'No such file or directory' and region_file.split('\\')[0] == 'poi' and os.path.exists(destination):
+					os.remove(destination)
+					source.get_server().logger.info('poi 删除成功: {}'.format(destination))
 			else:
 				msg = '成功'
 				flag = True


### PR DESCRIPTION
1. added poi able to update

This is mainly when a region is updated, and in the destination world where it's updated there are existing poi there. If that's the case with this change the poi will change, instead of not changing and staying in the air invisible. And if in the source world the poi doesn't exists poi will be deleted in the destination world.

2. removed print_log def

I noticed this function doesn't work properly and makes some errors, so I think it's a good idea to erase it, because it's not necessary at all.